### PR TITLE
docs: fill documentation gaps and fix inaccuracies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Forte is the full-stack web framework built on fn0.
 
 - [Overview](forte/overview.md) — Architecture and key packages
 - [Project Structure](forte/project-structure.md) — Directory layout and conventions
-- [CLI Reference](forte/cli.md) — All `forte` commands
+- [CLI Reference](forte/cli.md) — All `forte` commands (including login and cron jobs)
 - [Pages](forte/pages.md) — Page handlers, path/search params, redirects, cookies
 - [Actions & Tasks](forte/actions.md) — Server actions, hooks, queue tasks, admin tasks
 - [SDK Reference](forte/sdk.md) — `ForteRequest`, HTTP client, cookies, re-exported crates

--- a/docs/doc-db/overview.md
+++ b/docs/doc-db/overview.md
@@ -187,19 +187,42 @@ let rows = db.execute_raw(
 
 ## Mocking (Tests)
 
+Use `doc_db::memory()` to get an in-memory database. Register mock rules before running code under test; rules are consumed in FIFO order per `(op, pk, sk)` key.
+
 ```rust
 let db = doc_db::memory();
 
-// Set up expectations
+// Get: return data
 db.mock_get("User/id=42", "profile")
-    .returns(Some(my_data));
+    .returns(my_data_bytes);       // returns Ok(Some(bytes))
 
+// Get: return not found
+db.mock_get("User/id=99", "profile")
+    .returns_none();               // returns Ok(None)
+
+// Get: return error
+db.mock_get("User/id=00", "profile")
+    .returns_err("db error");      // returns Err(...)
+
+// Put: succeed
 db.mock_put("User/id=42", "profile")
     .returns_ok();
 
+// Put: fail
+db.mock_put("User/id=42", "profile")
+    .returns_err("write failed");
+
+// Delete: succeed
+db.mock_delete("User/id=42", "profile")
+    .returns_ok();
+
+// Delete: fail
+db.mock_delete("User/id=42", "profile")
+    .returns_err("delete failed");
+
 // ... run code under test ...
 
-db.clear_mocks();
+db.clear_mocks();  // remove all remaining rules
 ```
 
-The mock API is in `doc_db::mock`. Unknown from repository: the exact builder API surface — check `doc-db/src/mock.rs` for `MockGetBuilder`, `MockPutBuilder`, `MockDeleteBuilder`.
+Builder types: `MockGetBuilder`, `MockPutBuilder`, `MockDeleteBuilder` (in `doc_db::mock`, used via the `Database` methods above).

--- a/docs/fn0/overview.md
+++ b/docs/fn0/overview.md
@@ -102,11 +102,13 @@ Unknown from repository: detailed `fn0-cli` commands — check `fn0/cli/README.m
 
 fn0 has built-in OpenTelemetry support:
 
-- OTLP exporter via `fn0/fn0/src/otlp_hijack.rs`
+- OTLP span exporter via `fn0/fn0/src/otlp_hijack.rs` (worker-side) and `forte/sdk/src/otel.rs` (WASM-side)
 - Structured logging via `tracing`
-- Metrics and distributed tracing
+- Distributed tracing with per-request spans
 
-Unknown from repository: OTLP endpoint configuration for self-hosted deployments — check `fn0/fn0/src/telemetry.rs`.
+For Forte apps running on fn0 Cloud, traces are exported to `http://fn0-otel.fn0.dev/v1/traces`. The service name is controlled via the `OTEL_SERVICE_NAME` environment variable (defaults to `"forte-app"`).
+
+For self-hosted fn0 worker deployments, OTLP endpoint configuration is Unknown from repository — check `fn0/fn0/src/otlp_hijack.rs` and `fn0/worker/src/telemetry.rs`.
 
 ## Hijack Architecture
 

--- a/docs/forte/cli.md
+++ b/docs/forte/cli.md
@@ -73,9 +73,13 @@ Build and upload the project to fn0 Cloud.
 | Flag | Default | Description |
 |---|---|---|
 | `-p, --project <dir>` | `.` | Project directory |
+| `--name <name>` | — | Display name for first-time registration |
+
+If a `cron.yaml` file exists in the project root, its scheduled jobs are registered during deploy. See [Cron Jobs](#cron-jobs) below.
 
 ```sh
 forte deploy
+forte deploy --name "My App"
 ```
 
 ---
@@ -113,13 +117,20 @@ Creates:
 
 ---
 
-### `forte rename <new-name> [options]`
+### `forte login`
 
-Rename the deployed project (migrates Turso DB and switches subdomain).
+Authenticate with fn0 Cloud. Opens a browser to the fn0 tokens page, prompts you to paste an API token, and saves credentials locally (shared with the `fn0` CLI).
 
 | Flag | Default | Description |
 |---|---|---|
-| `-p, --project <dir>` | `.` | Project directory |
+| `--token <token>` | — | Provide token directly (skips interactive flow) |
+
+Tokens must start with `fn0_`. Credentials are saved to a local file (path printed on success).
+
+```sh
+forte login
+forte login --token fn0_xxxxx
+```
 
 ---
 
@@ -164,3 +175,23 @@ Same as `run` but targets a locally-running `forte dev` server.
 | Flag | Default | Description |
 |---|---|---|
 | `-P, --port <port>` | 3000 | Local dev server port |
+
+---
+
+## Cron Jobs
+
+Place a `cron.yaml` file in the project root to schedule queue tasks. The file is read during `forte deploy` and the jobs are registered with fn0 Cloud.
+
+```yaml
+# cron.yaml
+- function: send_digest_email
+  every_minutes: 60
+- function: cleanup_old_sessions
+  every_minutes: 1440
+```
+
+Each entry:
+- `function` — must match a file in `rs/src/queue_task/<name>.rs`, and that task's `Input` must be a unit struct (no fields).
+- `every_minutes` — run interval (must be ≥ 1).
+
+Cron jobs are not supported in local development (`forte dev`).

--- a/docs/forte/project-structure.md
+++ b/docs/forte/project-structure.md
@@ -6,6 +6,7 @@ A Forte project created by `forte init <name>` has the following layout:
 <name>/
 ├── Forte.toml                 # Project config (name, etc.)
 ├── Cargo.toml                 # Workspace root (members = ["rs"])
+├── cron.yaml                  # (optional) Scheduled cron job definitions
 ├── .gitignore
 │
 ├── rs/                        # Rust backend (compiles to WASM)
@@ -92,6 +93,17 @@ name = "my-app"
 ```
 
 The name determines the fn0 Cloud subdomain when deployed.
+
+## cron.yaml (optional)
+
+Place this file in the project root to schedule queue tasks on fn0 Cloud. Registered during `forte deploy`.
+
+```yaml
+- function: send_digest_email
+  every_minutes: 60
+```
+
+Each `function` must match a `rs/src/queue_task/<name>.rs` file whose `Input` is a unit struct. See [forte/cli.md#cron-jobs](cli.md#cron-jobs).
 
 ## Cargo.toml (rs/)
 

--- a/docs/forte/sdk.md
+++ b/docs/forte/sdk.md
@@ -133,9 +133,23 @@ let id = Uuid::new_v4();
 
 ## Randomness
 
+Backed by WASI random. All functions are `async`.
+
 ```rust
 use forte_sdk::rand;
-// See forte/sdk/src/rand.rs — Unknown from repository which exact API is exposed.
+
+// Fill a buffer with cryptographically secure random bytes
+rand::fill_bytes(&mut buf).await;
+
+// Get a Vec<u8> of secure random bytes
+let bytes: Vec<u8> = rand::get_random_bytes(32).await;
+
+// Get a single u64
+let n: u64 = rand::get_random_u64().await;
+
+// Insecure (fast) variants — not suitable for secrets
+rand::get_insecure_random_bytes(&mut buf).await;
+let n: u64 = rand::get_insecure_random_u64().await;
 ```
 
 ## Tracing / Logging
@@ -147,7 +161,9 @@ tracing::info!("processing request");
 tracing::error!("something failed: {}", err);
 ```
 
-OpenTelemetry is initialized once per instance on the first request (via `otel::init_once()`). OTLP exporter configuration is Unknown from repository — check `forte/sdk/src/otel.rs`.
+OpenTelemetry is initialized once per instance on the first request via `otel::init_once()`, which is called automatically by the `serve` function. Spans are exported to `http://fn0-otel.fn0.dev/v1/traces` (the fn0 Cloud collector) using the OTLP protobuf format.
+
+The service name defaults to `"forte-app"` and can be overridden with the `OTEL_SERVICE_NAME` environment variable.
 
 ## Re-exported Crates
 


### PR DESCRIPTION
## Summary

- **`forte/cli.md`** — Added missing `forte login` command; added `--name` flag to `forte deploy`; added a **Cron Jobs** section documenting the `cron.yaml` file format and constraints; removed `forte rename` which is not present in the CLI `Commands` enum
- **`forte/sdk.md`** — Replaced "Unknown from repository" for the `rand` module with the actual async API (`fill_bytes`, `get_random_bytes`, `get_random_u64`, insecure variants); fixed the tracing/OTel section to document the hardcoded OTLP endpoint (`http://fn0-otel.fn0.dev/v1/traces`) and `OTEL_SERVICE_NAME` env var support
- **`forte/project-structure.md`** — Added `cron.yaml` to the project tree diagram and added a section explaining the file
- **`doc-db/overview.md`** — Replaced "Unknown from repository" for the mock builder API with full method signatures (`returns`, `returns_none`, `returns_err`, `returns_ok`) for all three operation types
- **`fn0/overview.md`** — Replaced "Unknown from repository" for OTLP configuration with the actual endpoint and env var; distinguished worker-side vs WASM-side OTel paths
- **`README.md`** — Minor link text update

## Key repository areas inspected

- `forte/cli/src/cli/mod.rs` — CLI command enum (source of truth for CLI commands)
- `forte/cli/src/cli/login.rs`, `cron.rs`, `deploy.rs` — command implementations
- `forte/sdk/src/rand.rs`, `otel.rs`, `cookie_sign.rs`, `http.rs`, `serve.rs` — SDK module implementations
- `forte/macros/src/lib.rs` — `forte_doc` and `test` macro implementations
- `doc-db/src/mock.rs` — mock builder API
- `forte/codegen/src/lib.rs` — codegen entry points

## Uncertainties / TODOs

- `forte admin run-local` — `--input` and `--input-file` flags were verified in code but `--timeout-seconds` behavior for local runs is not tested; check `forte/cli/src/cli/admin.rs`
- Self-hosted fn0 worker OTLP configuration — the `otlp_hijack` and worker `telemetry.rs` paths were noted but not fully read; the documentation marks them as "Unknown from repository"
- `forte rename` was documented in the previous version but is absent from the `Commands` enum; if it was removed intentionally this PR removes it from docs, if it should still exist it needs a new implementation

https://claude.ai/code/session_01927Gy8fzKNsKFd7TVdh1tE

---
_Generated by [Claude Code](https://claude.ai/code/session_01927Gy8fzKNsKFd7TVdh1tE)_