### PR TITLE
docs: fix inaccuracies and fill documentation gaps in Forte framework

### DIFF
--- a/docs/fn0/overview.md
+++ b/docs/fn0/overview.md
@@ -52,32 +52,38 @@ These limits apply to fn0 Cloud. Self-hosted deployments can remove them.
 
 | Package | Version | Description |
 |---|---|---|
-| `fn0` | 0.2.27 | Core FaaS runtime (`ExecutionContext`, `Bundle`, `build_engine`) |
+| `fn0` | 0.2.28 | Core FaaS runtime (`ExecutionContext`, `Bundle`, `build_engine`) |
 | `fn0-cli` | 0.1.0 | Local development CLI |
-| `fn0-worker` | 0.3.23 | Worker binary (distributed execution node) |
-| `fn0-worker-agent` | 0.1.0 | Per-instance container supervisor (blue-green deploys, self DNS, in-host TCP proxy) |
+| `fn0-worker` | 0.3.24 | Worker binary (distributed execution node) |
+| `fn0-worker-agent` | 0.1.1 | Per-instance container supervisor (blue-green deploys, self DNS, in-host TCP proxy) |
 | `fn0-deploy` | 0.1.6 | fn0 Cloud deployment client |
 | `fn0-wasmtime` | 0.1.3 | Wasmtime wrapper with fn0-specific config |
 | `fn0-ski` | 0.1.4 | WinterCG-compatible JS runtime (Deno-based, no Node.js) |
 | `fn0-compiler` | 0.1.0 | Compiler utilities (internal) |
 | `hq` | 0.1.0 | Headquarter management service |
 
-## fn0-cli (Local Development)
+## fn0-cli Commands
 
-The fn0 CLI (`fn0/cli`) provides local development tooling:
+The fn0 CLI (`fn0/cli`) provides tooling for projects deployed directly to fn0 without Forte:
 
-```sh
-# Initialize a new fn0 project
-fn0 init
+| Command | Description |
+|---|---|
+| `fn0 init [--name <name>]` | Scaffold a new fn0 project (prompts for framework and language) |
+| `fn0 build` | Compile the project to WASM |
+| `fn0 local [--port <port>]` | Run locally on the given port (default: auto) |
+| `fn0 deploy` | Build and deploy to fn0 Cloud |
+| `fn0 destroy` | Delete the deployed project |
+| `fn0 rename <new-name>` | Rename the deployed project |
+| `fn0 login [token]` | Authenticate with fn0 Cloud |
+| `fn0 admin run <task>` | Run an admin task against the deployed app |
+| `fn0 domain add <domain>` | Attach a custom domain (CNAME) |
+| `fn0 domain remove` | Detach the custom domain |
+| `fn0 domain status` | Show custom domain status |
+| `fn0 secrets set <key> <value>` | Set a secret (injected via vault_hijack at runtime) |
+| `fn0 secrets list` | List secret keys |
+| `fn0 secrets unset <key>` | Remove a secret |
 
-# Build (compiles to WASM)
-fn0 build
-
-# Run locally
-fn0 local
-```
-
-Unknown from repository: detailed `fn0-cli` commands — check `fn0/cli/README.md` and `fn0/cli/src/`.
+> **Note:** Most Forte developers use `forte` CLI instead of `fn0` CLI. `fn0` CLI is for projects that use fn0 as a raw FaaS platform (e.g., Hono-based TypeScript apps).
 
 ## Supported Languages
 

--- a/docs/forte/actions.md
+++ b/docs/forte/actions.md
@@ -106,9 +106,9 @@ Background tasks live under `rs/src/queue_task/`. They have an `Input` struct an
 ```rust
 // rs/src/queue_task/send_email.rs
 use anyhow::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]  // both required: Deserialize for execution, Serialize for enqueue
 pub struct Input {
     pub to: String,
     pub subject: String,
@@ -125,8 +125,9 @@ To enqueue a task from anywhere in the backend:
 
 ```rust
 use crate::enqueue;
+use crate::queue_task::send_email;
 
-enqueue::send_email(enqueue::send_email::Input {
+enqueue::send_email(send_email::Input {
     to: "user@example.com".to_string(),
     subject: "Welcome".to_string(),
     body: "...".to_string(),

--- a/docs/forte/codegen.md
+++ b/docs/forte/codegen.md
@@ -130,7 +130,19 @@ For each page handler (`rs/src/pages/<path>/mod.rs`), it generates:
 - `fe/src/pages/<path>/.props.ts` — the `Props` type as a TypeScript discriminated union
 
 For each action handler (`rs/src/actions/<name>.rs`), it generates:
-- Type files for `Input` and `Output` (format: Unknown from repository — check `forte/rs-to-ts/`)
+- `fe/src/actions/.generated/<name>.ts` — Zod schema and TypeScript types for `Input` and `Output`
+
+For each hook handler (`rs/src/hooks/<name>.rs`), it generates:
+- `fe/src/hooks/.generated/<name>.ts` — Zod schema and TypeScript types for `Input` and `Output`
+
+Each generated file imports `zod` and exports:
+```ts
+export const InputSchema = z.object({ ... });
+export type Input = z.infer<typeof InputSchema>;
+
+export const OutputSchema = z.discriminatedUnion("t", [ ... ]);
+export type Output = z.infer<typeof OutputSchema>;
+```
 
 The generated Props type uses `{ t: "VariantName", v: { ... } }` shape for enum variants with fields.
 

--- a/docs/forte/pages.md
+++ b/docs/forte/pages.md
@@ -179,11 +179,25 @@ export default function IndexPage(props: Props) {
     if (props.t !== "Ok") {
         return <div>Error</div>;
     }
-    return <div>{props.v.message}</div>;
+    return <div>{props.message}</div>;
 }
 ```
 
-The `.props.ts` file is auto-generated from the Rust `Props` type by `forte-rs-to-ts`. The generated type uses a discriminated union with `t` (tag) and `v` (value) fields corresponding to enum variants.
+The `.props.ts` file is auto-generated from the Rust `Props` type by `forte-rs-to-ts`. It exports a Zod schema and a `Props` type as a TypeScript discriminated union on the `t` field.
+
+The JSON shape varies by variant kind:
+
+| Rust variant kind | JSON shape | TypeScript type |
+|---|---|---|
+| Unit: `Ok` | `{"t":"Ok"}` | `{ t: "Ok" }` |
+| Tuple/newtype: `Ok(String)` | `{"t":"Ok","v":"..."}` | `{ t: "Ok", v: string }` |
+| Struct: `Ok { message: String }` | `{"t":"Ok","message":"..."}` | `{ t: "Ok", message: string }` |
+
+Struct variant fields are spread alongside `t` (flat); there is no `v` wrapper. Rust field names are converted to camelCase (`user_name` → `userName`).
+
+**Example** for `Props::Ok { message: String }`:
+- JSON from Rust: `{"t":"Ok","message":"Hello"}`
+- TypeScript access: `props.message` (after narrowing with `props.t === "Ok"`)
 
 ## API Endpoints
 

--- a/docs/forte/sdk.md
+++ b/docs/forte/sdk.md
@@ -165,6 +165,42 @@ OpenTelemetry is initialized once per instance on the first request via `otel::i
 
 The service name defaults to `"forte-app"` and can be overridden with the `OTEL_SERVICE_NAME` environment variable.
 
+## `forte_json` — Serialization Format
+
+`forte-json` is a custom JSON serializer/deserializer used for all handler I/O. It differs from `serde_json` in two ways:
+
+**Serialization (Rust → JSON):**
+- Struct field names are converted to camelCase (`user_name` → `"userName"`)
+- Enum variants use a `t` discriminant field:
+
+| Variant kind | Rust | JSON |
+|---|---|---|
+| Unit | `Ok` | `{"t":"Ok"}` |
+| Tuple/newtype (1 field) | `Ok(String)` | `{"t":"Ok","v":"..."}` |
+| Struct | `Ok { message: String }` | `{"t":"Ok","message":"..."}` |
+
+For struct variants the fields are spread flat alongside `t`; there is no `v` wrapper.
+
+**Deserialization (JSON → Rust):**
+- All object keys are converted to snake_case before deserializing (`"userName"` → `"user_name"`)
+- This means TypeScript action input shapes use camelCase while Rust struct fields use snake_case
+
+```rust
+// Rust
+#[derive(Deserialize)]
+pub struct Input {
+    pub user_name: String,   // receives "userName" from the browser
+}
+```
+
+The API:
+```rust
+use forte_sdk::forte_json;
+
+let bytes: Vec<u8> = forte_json::to_vec(&my_value);
+let value: MyType = forte_json::from_slice(&bytes)?;
+```
+
 ## Re-exported Crates
 
 All re-exported at the crate root and usable via `forte_sdk::`:


### PR DESCRIPTION
## Summary

Documentation-only changes. Five files updated with accuracy fixes and missing content:

- **`docs/forte/pages.md`** — Fix React component example: struct variants serialize flat (`{"t":"Ok","message":"..."}` not `{"t":"Ok","v":{"message":"..."}}`), so the correct access is `props.message` not `props.v.message`. Added a variant-kind reference table.
- **`docs/forte/actions.md`** — Queue task `Input` must derive both `Serialize` and `Deserialize` (the generated `enqueue::*` functions call `serde_json::to_value(&input)`). Fix enqueue usage example to use `crate::queue_task::<name>::Input` (the `enqueue::<name>::Input` path does not exist).
- **`docs/forte/codegen.md`** — Replace "Unknown from repository" placeholder with actual output paths for action/hook TypeScript types (`fe/src/actions/.generated/<name>.ts`, `fe/src/hooks/.generated/<name>.ts`) and the Zod schema format.
- **`docs/fn0/overview.md`** — Replace "Unknown from repository" with a full fn0-cli command table (`init`, `build`, `deploy`, `destroy`, `rename`, `local`, `login`, `admin run`, `domain`, `secrets`). Update package versions (fn0 0.2.28, worker 0.3.24, agent 0.1.1).
- **`docs/forte/sdk.md`** — Add `forte-json` serialization format section documenting the `t`-discriminated enum shapes, snake_case→camelCase field conversion, and the `from_slice`/`to_vec` API.

## Test plan

- [ ] Verify docs render correctly in Markdown
- [ ] No application code changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWSCthsGfDjMCP9kwRcaVm)_